### PR TITLE
Adding note about installing extensions

### DIFF
--- a/Setup Instructions.md
+++ b/Setup Instructions.md
@@ -154,6 +154,12 @@ Click the check box to enable *Collapsible Headings*. Also make sure that *Freez
 
 ![Enable Collapsible Headings](img/colapsable-headings.png)
 
+**Note: If you don't see the Notebook Extensions tab, you may need to run this command, and restart Jupyter Notebook:*
+
+```
+$ jupyter contrib nbextension install --user
+```
+
 
 #### Now Run the Test Notebook
 Let's use Jupyter Notebook to perform some tests on our installation. Navigate back to the Jupyter Notebook home location by clicking the *Files* tab. Then, Click on *Test.ipynb* to launch the *Test* notebook: 


### PR DESCRIPTION
I installed the libraries with `virtualenv` on Linux, and the extensions tab didn't show up until I ran this command:

```
jupyter contrib nbextension install --user
```